### PR TITLE
docs: switch to uv

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,10 +37,13 @@ The **Agent Communication Protocol (ACP)** is an open standard with open governa
 
 ## Quickstart
 
+> [!NOTE]
+> This guide uses `uv`. See the [`uv` primer](https://agentcommunicationprotocol.dev/introduction/uv-primer.mdx) for more details.
+
 **1. Initialize your project**
 
 ```sh
-uv init
+uv init --python '>=3.11'
 ```
 
 **2. Add the ACP SDK**
@@ -82,7 +85,7 @@ server.run()
 **4. Start the ACP server**
 
 ```sh
-python agent.py
+uv run agent.py
 ```
 
 Your server should now be running at `http://localhost:8000`.
@@ -185,7 +188,7 @@ if __name__ == "__main__":
 **8. Run the ACP client**
 
 ```sh
-python client.py
+uv run client.py
 ```
 
 You should see the echoed response printed to your console. 🎉

--- a/docs/how-to/debug.mdx
+++ b/docs/how-to/debug.mdx
@@ -61,15 +61,18 @@ docker run -p 4318:6006 -i -t arizephoenix/phoenix
 In this example, we will focus only on the communication between the server and client. 
 Let's use the `Jaeger` for this example.
 
-> Be sure you have a running Jaeger instance before you start! See the [Run Jaeger](#run-jaeger) section for more details.
+<Warning>
+Be sure you have a running Jaeger instance before you start! See the [Run Jaeger](#run-jaeger) section for more details.
+</Warning>
 
 ### Init the repository
 
-```
-uv init
-```
+<Note>
+This guide uses `uv`. See the [`uv` primer](/introduction/uv-primer.mdx) for more details.
+</Note>
 
 ```
+uv init --python '>=3.11'
 uv add acp-sdk
 ```
 

--- a/docs/how-to/wrap-existing-agent.mdx
+++ b/docs/how-to/wrap-existing-agent.mdx
@@ -14,7 +14,7 @@ Once wrapped, your agent becomes:
 
 ## Simple agent
 
-<Tip>If you haven’t already, install the SDK: `pip install acp-sdk`</Tip>
+<Tip>If you haven’t already, install the SDK: `uv add acp-sdk`</Tip>
 
 Wrapping an agent with ACP is as simple as annotating a Python function.
 

--- a/docs/introduction/quickstart.mdx
+++ b/docs/introduction/quickstart.mdx
@@ -5,11 +5,15 @@ description: "Get up and running with ACP"
 
 This guide will walk you through using the Agent Communication Protocol (ACP) to create and run your first agent, interact with it using HTTP requests, and build a basic client.
 
+<Note>
+This guide uses `uv`. See the [`uv` primer](/introduction/uv-primer.mdx) for more details.
+</Note>
+
 <Steps>
 <Step title="Initialize your project">
 
 ```sh
-uv init
+uv init --python '>=3.11'
 ```
 
 </Step>
@@ -54,7 +58,7 @@ server.run()
 <Step title="Start the ACP server">
 
 ```sh
-python agent.py
+uv run agent.py
 ```
 
 Your server should now be running at http://localhost:8000.
@@ -162,7 +166,7 @@ if __name__ == "__main__":
 <Step title="Run the ACP client">
 
 ```sh
-python client.py
+uv run client.py
 ```
 
 You should see the echoed response printed to your console. 🎉

--- a/docs/introduction/uv-primer.mdx
+++ b/docs/introduction/uv-primer.mdx
@@ -1,0 +1,37 @@
+---
+title: "Primer on uv"
+description: "How to use the uv tool"
+---
+
+## What's `uv`?
+
+[`uv`](https://github.com/astral-sh/uv) is a modern all-in-one Python tool for managing Python installations, virtual environments, PyPI dependencies, project lockfiles, multi-project workspaces and virtually everything else you need for a Python project. It fully replaces many legacy tools, like `pip`, `pip-tools`, `pyenv`, `pipenv`, `virtualenv`, `venv`, etc.
+
+## Can I use ACP SDK without `uv`?
+
+Yes, the PyPI package `acp-sdk` can be used with `uv`, `pip`, `poetry`, or any other Python package installer. You will need `uv` only if you want to clone this repository and run the included examples.
+
+## How to install `uv`?
+
+These are our recommendations on how to install `uv`. For more options, follow the [official installation instructions](https://docs.astral.sh/uv/getting-started/installation/).
+
+| Operating System           | Installation Command                                                                                                                |
+| -------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| macOS (or Linux) with Brew | `brew install uv`                                                                                                                   |
+| Linux                      | `sudo apt install pipx && pipx ensurepath && pipx install uv`<br/><small>(replace `apt` with your distro's package manager)</small> |
+| Windows                    | `winget install --id=astral-sh.uv -e`                                                                                               |
+
+## How to use `uv`?
+
+Here's a quick table for common commands. For the full list of commands, see the [official documentation](https://docs.astral.sh/uv/getting-started/features/).
+
+Note that `uv` commands do not require the virtual environment to be "activated", they will always work with the project virtual environment.
+
+| Task                         | `uv` command                  | Legacy command                    |
+| ---------------------------- | ----------------------------- | --------------------------------- |
+| Set up a new project         | `uv init --python '>=3.11'`\* | `python -m venv .venv`            |
+| Run a Python file            | `uv run script.py`            | `python script.py`                |
+| Install a package            | `uv add <package>`            | `pip install <package>`           |
+| Install all project packages | `uv sync`                     | `pip install -r requirements.txt` |
+
+<small>*ACP SDK requires Python 3.11 or higher.</small>

--- a/python/README.md
+++ b/python/README.md
@@ -8,11 +8,12 @@ Agent Communication Protocol SDK for Python provides allows developers to serve 
 
 ## Installation
 
-Install with:
+Install according to your Python package manager:
 
-```shell
-pip install acp-sdk
-```
+- `uv add acp-sdk`
+- `pip install acp-sdk`
+- `poetry add acp-sdk`
+- ...
 
 ## Quickstart
 


### PR DESCRIPTION
Add a short (link-only) section in the docs on `uv` for people that might be confused about it. Switch the remaining places in the docs to use `uv`.