### PR TITLE
chore: fix docs package.json license

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -9,7 +9,7 @@
   },
   "keywords": [],
   "author": "IBM Corp.",
-  "license": "ISC",
+  "license": "Apache-2.0",
   "packageManager": "pnpm@9.9.0+sha512.60c18acd138bff695d339be6ad13f7e936eea6745660d4cc4a776d5247c540d0edee1a563695c183a66eb917ef88f2b4feb1fc25f32a7adcadc7aaf3438e99c1",
   "devDependencies": {
     "mintlify": "^4.0.406"


### PR DESCRIPTION
ISC was put in by the npm template, but this is an Apache-2.0 project.