### PR TITLE
doc: add acp agent generator to examples

### DIFF
--- a/docs/introduction/example-agents.mdx
+++ b/docs/introduction/example-agents.mdx
@@ -67,3 +67,9 @@ An example of a [LangGraph](https://langchain-ai.github.io/langgraph/) agent tha
 
 The complete source code is available on <Icon icon="github" /> [GitHub](https://github.com/i-am-bee/acp/tree/main/examples/python/langgraph-greeting).
 
+
+## ACP Agent Generator
+
+This example demonstrates how to create an agent that dynamically generates other agents using the Agent Communication Protocol (ACP).
+
+The complete source code is available on <Icon icon="github"/> [GitHub](https://github.com/i-am-bee/acp/tree/main/examples/python/acp-agent-generator).


### PR DESCRIPTION
updated example doc page to include acp agent generator