### PR TITLE
Fix check for PRODUCTION_MODE

### DIFF
--- a/python/src/acp_sdk/server/server.py
+++ b/python/src/acp_sdk/server/server.py
@@ -311,7 +311,7 @@ class Server:
 
     async def _register_agent(self) -> None:
         """If not in PRODUCTION mode, register agent to the beeai platform and provide missing env variables"""
-        if os.getenv("PRODUCTION_MODE", "").lower() != "true":
+        if os.getenv("PRODUCTION_MODE", "").lower() in ["true", "1"]:
             logger.debug("Agent is not automatically registered in the production mode.")
             return
 

--- a/python/src/acp_sdk/server/server.py
+++ b/python/src/acp_sdk/server/server.py
@@ -311,7 +311,7 @@ class Server:
 
     async def _register_agent(self) -> None:
         """If not in PRODUCTION mode, register agent to the beeai platform and provide missing env variables"""
-        if os.getenv("PRODUCTION_MODE", False):
+        if os.getenv("PRODUCTION_MODE", "").lower() != "true":
             logger.debug("Agent is not automatically registered in the production mode.")
             return
 


### PR DESCRIPTION
The current implementation will be "truthy" if set to the string "False." This change makes anything that doesn't explicitly set `PRODUCTION_MODE` to a case-insensitive version of "true" to be false.