### PR TITLE
feat: prevent server fingerprinting

### DIFF
--- a/python/src/acp_sdk/server/server.py
+++ b/python/src/acp_sdk/server/server.py
@@ -104,6 +104,9 @@ class Server:
         if self._server:
             raise RuntimeError("The server is already running")
 
+        if headers is None:
+            headers = [("server", "ACP Agent")]
+
         import uvicorn
 
         if configure_logger:

--- a/python/src/acp_sdk/server/server.py
+++ b/python/src/acp_sdk/server/server.py
@@ -105,7 +105,9 @@ class Server:
             raise RuntimeError("The server is already running")
 
         if headers is None:
-            headers = [("server", "ACP Agent")]
+            headers = [("server", "acp")]
+        elif not any(k.lower() == "server" for k, _ in headers):
+            headers.append(("server", "acp"))
 
         import uvicorn
 


### PR DESCRIPTION
### ✨ Summary
This PR introduces a custom server value to prevent server fingerprinting.

### 🐛 Problem
Having a custom Server header in the HTTP response is important primarily for security and privacy reasons. Here's why:

1. Security through obscurity (attack surface reduction)

    Default server headers often reveal details like:
    ```
    Server: Apache/2.4.41 (Ubuntu)
    Server: nginx/1.18.0
    Server: gunicorn/20.1.0
    ```
    
    This tells an attacker exactly:
    - What web server or application framework you're using.
    - What version it's running.
    - Sometimes even the OS underneath.

    Why this is bad:
    - If the server or version has known vulnerabilities, an attacker can use this information to:
        - Tailor attacks using known exploits (e.g., CVEs).
        - Target automated scanners at vulnerable services.

2. Avoiding information leakage

    Follow the principle of least information disclosure — don’t give away more information than necessary. Default headers give away implementation details that most users don’t need.

3. Branding or environment marking

    Setting a custom Server header (like Server: ACP Agent) can be useful:
      - To track responses across services.
      - To identify environments (e.g., Server: ACP Agent Prod vs. ACP Agent Dev).
      - As a subtle form of branding or diagnostics.

4. Compliance and hardening standards

Many security benchmarks (e.g., CIS Benchmarks, OWASP) recommend removing or modifying identifying headers like Server, X-Powered-By, etc.

#### Why it still makes sense in open source

1. Reduces automated scanning
    Even if attackers could figure out what server you're using, not advertising it:
    - Avoids being picked up by mass scanners looking for vulnerable versions.
    - Helps avoid being lumped into broad bot-driven attacks.

2. Defense-in-depth
    Security is not just about secrets — it's about layers. Hiding Server isn't a silver bullet, but it adds friction to attackers:
    - They may need to do deeper probing to fingerprint your app.
    - That’s extra work and possibly triggers detection mechanisms.


### ✅ Changes

If no headers are provided, initialize with a `Server: ACP Agent` header.

### 🧩 Motivation

| Reason    | Risk Avoided or Benefit |
| -------- | ------- |
| Prevents server fingerprinting  | Reduces targeted attacks    |
| Reduces info leakage | Hardens security posture     |
| Enables environment tracking    | Aids debugging/logging    |
| Meets compliance standards    | Avoids audit failures    |


### 🧪 Testing
- 

### 🧠 Notes

Before the change:

<img width="1416" alt="Screenshot at May 14 10-19-00" src="https://github.com/user-attachments/assets/797f12e5-2797-46a0-8349-02dcaf860152" />

After the change:

<img width="1409" alt="Screenshot at May 14 10-20-50" src="https://github.com/user-attachments/assets/902b8cc6-5c70-4b96-bae4-08f448157c66" />



