### PR TITLE
feat(spec): add message role

### DIFF
--- a/docs/spec/openapi.yaml
+++ b/docs/spec/openapi.yaml
@@ -6,7 +6,7 @@ info:
   license:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0.html
-  version: 0.1.0
+  version: 0.2.0
 externalDocs:
   description: Comprehensive documentation for ACP
   url: https://agentcommunicationprotocol.dev
@@ -285,8 +285,20 @@ components:
         completed_at:
           type: string
           format: date-time
+        role:
+          description: |
+            Specifies the sender of the message. Allowed values are:
+            - `"user"` for messages sent by an end-user.
+            - Any other string indicating the specific name of the agent sending the message.
+          oneOf:
+            - type: string
+              enum: [user]
+            - type: string
+              description: Name of the agent.
+              example: summarizer_agent
       required:
         - parts
+        - role
     AwaitRequest:
       type: object
     AwaitResume:

--- a/docs/spec/openapi.yaml
+++ b/docs/spec/openapi.yaml
@@ -286,16 +286,16 @@ components:
           type: string
           format: date-time
         role:
+          type: string
           description: |
-            Specifies the sender of the message. Allowed values are:
+            Specifies the sender of the message. Allowed values:
             - `"user"` for messages sent by an end-user.
-            - Any other string indicating the specific name of the agent sending the message.
-          oneOf:
-            - type: string
-              enum: [user]
-            - type: string
-              description: Name of the agent.
-              example: summarizer_agent
+            - `"agent/{agent_name}"` for messages sent by an agent, where `{agent_name}` is the identifier of the agent.
+          examples:
+            - user
+            - agent/summarizer
+            - agent/data_processor
+          pattern: '^(user|agent\/[a-zA-Z0-9_\-]+)$'
       required:
         - parts
         - role


### PR DESCRIPTION
Refs https://github.com/i-am-bee/acp/issues/141

This PR adds a `role` field to the Message schema in the OpenAPI specification.

### Motivation

It's important to clearly track message originators within conversation history. Introducing the `role` field explicitly captures whether a message originated from a `user` or a specific agent, supporting the following scenarios:

- **User ↔ single agent** conversations
- **User ↔ multiple agents** interactions
- **Agent ↔ agent** communication

This addition maintains compatibility with standard conversational roles (`user`, `assistant`) widely adopted by chat-based LLM templates.

### Next actions

- [ ] Update SDKs
- [ ] Update existing examples
- [ ] Update docs