### PR TITLE
feat: add missing parameters to openapi

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -68,8 +68,10 @@
               "/spec/agents-get",
               "/spec/run-create",
               "/spec/run-get",
+              "/spec/run-get-events",
               "/spec/run-resume",
-              "/spec/run-cancel"
+              "/spec/run-cancel",
+              "/spec/ping"
             ]
           }
         ]

--- a/docs/spec/openapi.yaml
+++ b/docs/spec/openapi.yaml
@@ -76,6 +76,13 @@ paths:
         - agent
       description: Get Agent
       operationId: getAgent
+      parameters:
+        - name: name
+          in: path
+          required: true
+          description: The name of the agent to retrieve.
+          schema:
+            type: string
       responses:
         "200":
           description: Successful operation

--- a/docs/spec/openapi.yaml
+++ b/docs/spec/openapi.yaml
@@ -135,6 +135,14 @@ paths:
         - run
       description: Read state of a run
       operationId: getRun
+      parameters:
+        - name: run_id
+          in: path
+          required: true
+          description: UUID of the run to retrieve.
+          schema:
+            type: string
+            format: uuid
       responses:
         "200":
           description: Status successfully read
@@ -186,6 +194,14 @@ paths:
         - run
       description: Cancel run
       operationId: cancelRun
+      parameters:
+        - name: run_id
+          in: path
+          required: true
+          description: UUID of the run to cancel.
+          schema:
+            type: string
+            format: uuid
       responses:
         "202":
           description: Run cancelling
@@ -205,6 +221,14 @@ paths:
         - run
       description: List events of a run
       operationId: listRunEvents
+      parameters:
+        - name: run_id
+          in: path
+          required: true
+          description: UUID of the run for which to fetch events.
+          schema:
+            type: string
+            format: uuid
       responses:
         "200":
           description: Successful operation

--- a/docs/spec/ping.mdx
+++ b/docs/spec/ping.mdx
@@ -1,0 +1,4 @@
+---
+title: "Ping"
+openapi: "GET /ping"
+---

--- a/docs/spec/run-get-events.mdx
+++ b/docs/spec/run-get-events.mdx
@@ -1,0 +1,4 @@
+---
+title: "Get Run Events"
+openapi: "GET /runs/{run_id}/events"
+---


### PR DESCRIPTION
Add a `name` parameter to `/agents/{name}` so that Mintlify can generate a form to set it.

https://github.com/user-attachments/assets/e0b5b36b-e1cc-48f3-9df4-e35d4b8d8881

<br>

Similarly, add `run_id` parameter to:
- `/runs/{run_id}`
- `/runs/{run_id}/cancel`
- `/runs/{run_id}/events`