### PR TITLE
feat: add option to enable/disable default middleware in create_app

### DIFF
--- a/python/src/acp_sdk/server/app.py
+++ b/python/src/acp_sdk/server/app.py
@@ -69,6 +69,7 @@ def create_app(
     forward_resources: bool = True,
     lifespan: Lifespan[AppType] | None = None,
     dependencies: list[Depends] | None = None,
+    default_middleware: bool = True,
 ) -> FastAPI:
     if not forward_resources and (
         resource_store is None
@@ -96,13 +97,15 @@ def create_app(
         dependencies=dependencies,
     )
 
-    app.add_middleware(
-        CORSMiddleware,
-        allow_origins=["https://agentcommunicationprotocol.dev"],
-        allow_methods=["*"],
-        allow_headers=["*"],
-        allow_credentials=True,
-    )
+    if default_middleware:
+        app.add_middleware(
+            CORSMiddleware,
+            allow_origins=["https://agentcommunicationprotocol.dev"],
+            allow_methods=["*"],
+            allow_headers=["*"],
+            allow_credentials=True,
+        )
+    
 
     agents: dict[AgentName, AgentManifest] = {agent.name: agent for agent in agents}
 


### PR DESCRIPTION
I have made it such that in default it will use the middleware which was already present. You can change the value for the default and then the user can create their own middleware. ISSUE https://github.com/i-am-bee/acp/issues/211

If this is ok, I shall make the changes in the documentation for further specifying on this