### PR TITLE
feat: proposal for agent configuration

### DIFF
--- a/examples/python/basic/uv.lock
+++ b/examples/python/basic/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.11, <4.0"
 
 [[package]]
 name = "acp-sdk"
-version = "0.13.0"
+version = "1.0.0"
 source = { editable = "../../../python" }
 dependencies = [
     { name = "cachetools" },

--- a/examples/python/beeai-chat/agent.py
+++ b/examples/python/beeai-chat/agent.py
@@ -1,10 +1,12 @@
 from collections.abc import AsyncGenerator
 
+from acp_sdk.models.models import MessagePart, TrajectoryMetadata
+
 
 import beeai_framework
 from acp_sdk import Message
 from acp_sdk.models import Metadata, Annotations
-from acp_sdk.models.platform import PlatformUIAnnotation, PlatformUIType
+from acp_sdk.models.platform import AgentConfiguration, ConfigurationField, PlatformUIAnnotation, PlatformUIType
 from acp_sdk.server import Context, Server
 from beeai_framework.agents.react import ReActAgent, ReActAgentUpdateEvent
 from beeai_framework.backend import AssistantMessage, UserMessage
@@ -17,7 +19,6 @@ from beeai_framework.tools.weather.openmeteo import OpenMeteoTool
 
 server = Server()
 
-
 def to_framework_message(role: str, content: str) -> beeai_framework.backend.Message:
     match role:
         case "user":
@@ -28,6 +29,20 @@ def to_framework_message(role: str, content: str) -> beeai_framework.backend.Mes
             raise ValueError(f"Unsupported role {role}")
 
 
+def get_tools(input: list[Message]) -> list[AnyTool]:
+    for message in input:
+        for part in message.parts:
+            if (
+                part.metadata
+                and part.metadata.kind == "configuration"
+                and part.metadata.key == "tools"
+                and part.metadata.value is True
+            ):
+                return [WikipediaTool(), OpenMeteoTool(), DuckDuckGoSearchTool()]
+
+    return []
+
+
 @server.agent(
     metadata=Metadata(
         annotations=Annotations(
@@ -35,6 +50,13 @@ def to_framework_message(role: str, content: str) -> beeai_framework.backend.Mes
                 ui_type=PlatformUIType.CHAT,
                 user_greeting="Let's chat!",
                 display_name="Chat Agent",
+                configuration=[
+                    AgentConfiguration(
+                        name="tools",
+                        description="Enable Tools",
+                        type=ConfigurationField.BOOLEAN,
+                    )
+                ],
             )
         )
     )
@@ -48,11 +70,8 @@ async def chat_agent(input: list[Message], context: Context) -> AsyncGenerator:
     # ensure the model is pulled before running
     llm = ChatModel.from_name("ollama:llama3.1", ChatModelParameters(temperature=0))
 
-    # Configure tools
-    tools: list[AnyTool] = [WikipediaTool(), OpenMeteoTool(), DuckDuckGoSearchTool()]
-
     # Create agent with memory and tools
-    agent = ReActAgent(llm=llm, tools=tools, memory=TokenMemory(llm))
+    agent = ReActAgent(llm=llm, tools=get_tools(input), memory=TokenMemory(llm))
 
     history = [message async for message in context.session.load_history()]
     framework_messages = [to_framework_message(message.role, str(message)) for message in history + input]
@@ -60,16 +79,17 @@ async def chat_agent(input: list[Message], context: Context) -> AsyncGenerator:
 
     async for data, event in agent.run():
         match (data, event.name):
-            case (ReActAgentUpdateEvent(), "partial_update"):
+            case (ReActAgentUpdateEvent(), "update"):
                 update = data.update.value
                 if not isinstance(update, str):
                     update = update.get_text_content()
                 match data.update.key:
-                    case "thought" | "tool_name" | "tool_input" | "tool_output":
-                        yield {data.update.key: update}
+                    case "tool_name":
+                        yield MessagePart(metadata=TrajectoryMetadata(tool_name=update))
+                    case "thought":
+                        yield MessagePart(metadata=TrajectoryMetadata(message=update))
                     case "final_answer":
                         yield Message(parts=[MessagePart(content=update)])
-                last_key = data.update.key
 
 
 if __name__ == "__main__":

--- a/examples/python/beeai-chat/uv.lock
+++ b/examples/python/beeai-chat/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.11, <4.0"
 
 [[package]]
 name = "acp-sdk"
-version = "0.10.1"
+version = "1.0.0"
 source = { editable = "../../../python" }
 dependencies = [
     { name = "cachetools" },

--- a/python/src/acp_sdk/models/models.py
+++ b/python/src/acp_sdk/models/models.py
@@ -138,9 +138,13 @@ class TrajectoryMetadata(BaseModel):
     kind: Literal["trajectory"] = "trajectory"
     message: Optional[str] = None
     tool_name: Optional[str] = None
-    tool_input: Optional[AnyModel] = None
-    tool_output: Optional[AnyModel] = None
+    tool_input: Optional[AnyModel | str] = None
+    tool_output: Optional[AnyModel | str] = None
 
+class ConfigurationMetadata(BaseModel):
+    kind: Literal["configuration"] = "configuration"
+    key: str
+    value: Any
 
 class MessagePart(BaseModel):
     name: Optional[str] = None
@@ -151,7 +155,7 @@ class MessagePart(BaseModel):
 
     model_config = ConfigDict(extra="allow")
 
-    metadata: Optional[CitationMetadata | TrajectoryMetadata] = Field(discriminator="kind", default=None)
+    metadata: Optional[CitationMetadata | TrajectoryMetadata | ConfigurationMetadata] = Field(discriminator="kind", default=None)
 
     def model_post_init(self, __context: Any) -> None:
         if self.content is not None and self.content_url is not None:

--- a/python/src/acp_sdk/models/models.py
+++ b/python/src/acp_sdk/models/models.py
@@ -141,6 +141,7 @@ class TrajectoryMetadata(BaseModel):
     tool_input: Optional[AnyModel] = None
     tool_output: Optional[AnyModel] = None
 
+
 class ConfigurationMetadata(BaseModel):
     """
     Represents configuration to alter agent's behavior.
@@ -149,9 +150,11 @@ class ConfigurationMetadata(BaseModel):
     - key: The name of the configuration setting.
     - value: The value of the configuration setting.
     """
+
     kind: Literal["configuration"] = "configuration"
     key: str
     value: Any
+
 
 class MessagePart(BaseModel):
     name: Optional[str] = None
@@ -162,7 +165,9 @@ class MessagePart(BaseModel):
 
     model_config = ConfigDict(extra="allow")
 
-    metadata: Optional[CitationMetadata | TrajectoryMetadata | ConfigurationMetadata] = Field(discriminator="kind", default=None)
+    metadata: Optional[CitationMetadata | TrajectoryMetadata | ConfigurationMetadata] = Field(
+        discriminator="kind", default=None
+    )
 
     def model_post_init(self, __context: Any) -> None:
         if self.content is not None and self.content_url is not None:

--- a/python/src/acp_sdk/models/models.py
+++ b/python/src/acp_sdk/models/models.py
@@ -138,10 +138,17 @@ class TrajectoryMetadata(BaseModel):
     kind: Literal["trajectory"] = "trajectory"
     message: Optional[str] = None
     tool_name: Optional[str] = None
-    tool_input: Optional[AnyModel | str] = None
-    tool_output: Optional[AnyModel | str] = None
+    tool_input: Optional[AnyModel] = None
+    tool_output: Optional[AnyModel] = None
 
 class ConfigurationMetadata(BaseModel):
+    """
+    Represents configuration to alter agent's behavior.
+
+    Properties:
+    - key: The name of the configuration setting.
+    - value: The value of the configuration setting.
+    """
     kind: Literal["configuration"] = "configuration"
     key: str
     value: Any

--- a/python/src/acp_sdk/models/platform.py
+++ b/python/src/acp_sdk/models/platform.py
@@ -7,6 +7,7 @@ class PlatformUIType(str, Enum):
     CHAT = "chat"
     HANDSOFF = "hands-off"
 
+
 class ConfigurationField(str, Enum):
     BOOLEAN = "boolean"
 

--- a/python/src/acp_sdk/models/platform.py
+++ b/python/src/acp_sdk/models/platform.py
@@ -7,6 +7,9 @@ class PlatformUIType(str, Enum):
     CHAT = "chat"
     HANDSOFF = "hands-off"
 
+class ConfigurationField(str, Enum):
+    BOOLEAN = "boolean"
+
 
 class AgentToolInfo(BaseModel):
     name: str
@@ -14,9 +17,16 @@ class AgentToolInfo(BaseModel):
     model_config = ConfigDict(extra="allow")
 
 
+class AgentConfiguration(BaseModel):
+    name: str
+    description: str | None = None
+    type: ConfigurationField
+
+
 class PlatformUIAnnotation(BaseModel):
     ui_type: PlatformUIType
     user_greeting: str | None = None
     display_name: str | None = None
+    configuration: list[AgentConfiguration] = []
     tools: list[AgentToolInfo] = []
     model_config = ConfigDict(extra="allow")


### PR DESCRIPTION
Simple proposal for agent configuration.

The main question to be answered:

Does it make sense to keep the configuration as part of message part metadata?

Because of streaming by definition we can't guarantee transactionality, where configuration has to be transactionaly bound to the run. On the other hand streaming is momentarily only possible on output, not input.


Demo in platform:

https://github.com/user-attachments/assets/6b444b3e-f125-4336-8184-7332cac01996

