### PR TITLE
fix: update redis-py close method usage

### DIFF
--- a/python/src/acp_sdk/server/store/redis_store.py
+++ b/python/src/acp_sdk/server/store/redis_store.py
@@ -40,4 +40,4 @@ class RedisStore(Store[T], Generic[T]):
                     yield await self.get(key)
         finally:
             await pubsub.unsubscribe(channel)
-            await pubsub.close()
+            await pubsub.aclose()


### PR DESCRIPTION
## PR Summary
This small PR updated the Redis pubsub cleanup logic to comply with the latest redis-py async API. This avoids deprecated behavior:
```python
DeprecationWarning: Call to deprecated close. (Use aclose() instead) -- Deprecated since version 5.0.1.
```